### PR TITLE
Add:ユーザー登録時のバリデーションを定義

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+  devise :database_authenticatable, :registerable, :validatable
+
+  validates :name, presence: true, length: { maximum:20 }
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,12 +178,12 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this


### PR DESCRIPTION
## 概要
ユーザーデータ登録時のバリデーションを定義しました

## 内容
- デフォルトで定義されているバリデーションを確認
  - email：必須、指定の正規表現に合致すること
  - password：必須、password_confirmationと一致すること、指定の文字数であること
- `app/models/user.rb`および`config/initializers/devise.rb`を編集し、以下のバリデーションを定義
  - name：必須、20文字以下
  - email：正規表現を変更
  - password：文字数を8文字以上に変更

## 確認
rails consoleにアクセスし、定義したバリデーションを満たさないデータが登録されないことを確認しました
```bash
user = User.new(name: 'invalid_data', email: 'invalid_data', password: 'invalid_data')
user.valid? #=> false
user.errors.full_messages #=> エラーメッセージ
```

## 参考文献
- [deviseのvalidatableモジュールのソースコード](https://github.com/heartcombo/devise/blob/main/lib/devise/models/validatable.rb)

Closes #16 