### PR TITLE
Add:ユーザーログイン用のビューおよびフォームを作成

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,10 @@
 
   <body>
     <!-- ヘッダー -->
-    <%= render 'shared/header' %>
+    <%= render user_signed_in? ? 'shared/header' : 'shared/before_login_header' %>
+
     <%= yield %>
+
     <!-- フッター -->
     <div class="fixed bottom-0 w-full">
       <%= render 'shared/footer' %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -8,10 +8,8 @@
     <div class="flex flex-1 justify-end px-2">
       <div class="flex items-stretch">
         <%= link_to 'コース一覧', '#', class: "btn btn-ghost"%>
-
-        <%# ログイン済みユーザー向け %>
-        <%= link_to 'コース作成', '#', class: "btn btn-ghost"%>
-        <%= link_to 'ログアウト', '#', class: "btn btn-ghost"%>
+        <%= link_to '新規登録', new_user_registration_path, class: "btn btn-ghost"%>
+        <%= link_to 'ログイン', new_user_session_path, class: "btn btn-ghost"%>
       </div>
     </div>
   </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,0 +1,26 @@
+<h2>Log in</h2>
+
+<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password %><br />
+    <%= f.password_field :password, autocomplete: "current-password" %>
+  </div>
+
+  <% if devise_mapping.rememberable? %>
+    <div class="field">
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
+    </div>
+  <% end %>
+
+  <div class="actions">
+    <%= f.submit "Log in" %>
+  </div>
+<% end %>
+
+<%= render "users/shared/links" %>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,26 +1,23 @@
-<h2>Log in</h2>
+<div class="container mx-auto">
+  <div class="grid grid-cols-1 gap-4 place-items-center">
+    <h2>ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <%= form_with model: resource, url: session_path(resource_name) do |f| %>
+      <div class="mb-3">
+        <%= f.label :email, class: "label" %>
+        <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "input input-bordered" %>
+      </div>
+    
+      <div class="mb-3">
+        <%= f.label :password, class: "label" %>
+        <%= f.password_field :password, autocomplete: "current-password", class: "input input-bordered" %>
+      </div>
+
+      <div class="flex justify-center">
+        <%= f.submit "ログイン", class: "btn btn-accent" %>
+      </div>
+    <% end %>
+
+    <%= render "users/shared/links" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
-
-<%= render "users/shared/links" %>
+</div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "新規登録ページへ", new_registration_path(resource_name), class: "btn btn-link" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>


### PR DESCRIPTION
## 概要
ユーザーログイン機能を実装するため、認証処理を行うためのviewおよびフォームを作成しました

## 内容
### ログイン用のビューを作成
- `app/views/users/sessions/new.html.erb`を作成
```bash
rails g devise:views users -v sessions
```
- 下記のフォームを作成
  - email
  - password

### 未ログインユーザー用のヘッダーを作成
- `app/views/shared/_before_login_header.html.erb`を作成
- 下記項目を有するヘッダーを作成
  - コース一覧
  - 新規登録
  - ログイン
- セッション状態によって表示するヘッダーを切替
  - `app/views/layouts/application.html.erb`の編集

## 確認
- ログインページのフォームから送信したデータがDBに保存されることを確認しました
- セッション状態によって表示されるヘッダーが変わることを確認しました
  - ログイン時：`app/views/shared/_header.html.erb`
  - 未ログイン時：`app/views/shared/_before_login_header.html.erb`

Closes #18 