### PR TITLE
Add:ログアウト処理の実装

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,9 +14,9 @@ class Users::SessionsController < Devise::SessionsController
   end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    super
+  end
 
   protected
 
@@ -25,7 +25,13 @@ class Users::SessionsController < Devise::SessionsController
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
 
+  # ログイン後のリダイレクト先
   def after_sign_in_path_for(resource)
+    root_path
+  end
+
+  # ログアウト後のリダイレクト先
+  def after_sign_out_path_for(resource)
     root_path
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,7 +11,7 @@
 
         <%# ログイン済みユーザー向け %>
         <%= link_to 'コース作成', '#', class: "btn btn-ghost"%>
-        <%= link_to 'ログアウト', '#', class: "btn btn-ghost"%>
+        <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "btn btn-ghost"%>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## 概要
ログアウト処理を実装しました

## 内容
### コントローラ
`app/controllers/users/sessions_controller.rb`
- ログアウト後のリダイレクト先をルートパスに指定

### ビュー
- `app/views/shared/_header.html.erb`を編集し、ログアウトボタンにリンクを追加

## 確認
- ログイン後、ログアウトボタンをクリックし、ログアウト処理が実施されることを確認しました
- ログアウト後、トップページに遷移し、ヘッダーに「新規登録」「ログイン」ボタンが表示されていることを確認しました

## 参考文献
- [devise/sessions_controller.rb](https://github.com/heartcombo/devise/blob/main/app/controllers/devise/sessions_controller.rb)

Closes #19 