### PR TITLE
Add:coursesおよびmarkersテーブルの作成

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -1,0 +1,2 @@
+class Course < ApplicationRecord
+end

--- a/app/models/marker.rb
+++ b/app/models/marker.rb
@@ -1,0 +1,2 @@
+class Marker < ApplicationRecord
+end

--- a/db/migrate/20241229053052_create_courses.rb
+++ b/db/migrate/20241229053052_create_courses.rb
@@ -1,0 +1,8 @@
+class CreateCourses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :courses do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20241229053052_create_courses.rb
+++ b/db/migrate/20241229053052_create_courses.rb
@@ -1,6 +1,12 @@
 class CreateCourses < ActiveRecord::Migration[7.0]
   def change
     create_table :courses do |t|
+      t.string :title,                            null: false, default: ""
+      t.text :body
+      t.decimal :distance, precision: 5, scale: 2
+      t.string :address
+      t.string :encoded_polyline,                 null: false, default: ""
+      t.references :user, foreign_key: true
 
       t.timestamps
     end

--- a/db/migrate/20241229055035_create_markers.rb
+++ b/db/migrate/20241229055035_create_markers.rb
@@ -1,8 +1,13 @@
 class CreateMarkers < ActiveRecord::Migration[7.0]
   def change
     create_table :markers do |t|
+      t.st_point :location, geographic: true
+      t.integer :order
+      t.references :course, foreign_key: true
 
       t.timestamps
     end
+
+    add_index(:markers, [:course_id, :order], unique: true)
   end
 end

--- a/db/migrate/20241229055035_create_markers.rb
+++ b/db/migrate/20241229055035_create_markers.rb
@@ -1,0 +1,8 @@
+class CreateMarkers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :markers do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_29_053052) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_29_055035) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -25,6 +25,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_29_053052) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_courses_on_user_id"
+  end
+
+  create_table "markers", force: :cascade do |t|
+    t.geography "location", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
+    t.integer "order"
+    t.bigint "course_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["course_id", "order"], name: "index_markers_on_course_id_and_order", unique: true
+    t.index ["course_id"], name: "index_markers_on_course_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -45,4 +55,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_29_053052) do
   end
 
   add_foreign_key "courses", "users"
+  add_foreign_key "markers", "courses"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_22_032441) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_29_053052) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
+
+  create_table "courses", force: :cascade do |t|
+    t.string "title", default: "", null: false
+    t.text "body"
+    t.decimal "distance", precision: 5, scale: 2
+    t.string "address"
+    t.string "encoded_polyline", default: "", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_courses_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -32,4 +44,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_22_032441) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "courses", "users"
 end


### PR DESCRIPTION
## 概要
コース作成機能を実装するため、コースに関するデータをDBに登録できるようにしました

## 内容
### coursesテーブルの作成
```bash
rails g model course # 生成したマイグレーションファイルを編集
rails db:migrate
```
attribute
- title (string)：タイトル
- body (text)：本文
- distance (decimal)：コースの距離
- adress (string)：コースの場所
- encoded_polyline (string)：コースのポリラインデータ
- user_id (integer)：外部キー

制約
- title：nullを許容しない
- encoded_polyline：nullを許容しない
- user_id：外部キー

### markersテーブルの作成
```bash
rails g model marker # 生成したマイグレーションファイルを編集
rails db:migrate
```
attribute
- location (st_point)：コースのマーカーの緯度・経度
- order (integer)：マーカーの順番
- course_id (integer)：外部キー

制約
- course_id：外部キー
- course_idとorder：一意であること

## 確認
db/schema.rbにcoursesテーブルおよびmarkersテーブルが作成されていることを確認しました

Closes #22 