### PR TITLE
Add:コース作成画面にマップを表示

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -4,10 +4,18 @@ async function initMap() {
   // 必要なライブラリをインポート
   const { Map } = await google.maps.importLibrary("maps");
 
-  map = new Map(document.getElementById("map"), {
-    center: { lat: -34.397, lng: 150.644 },
-    zoom: 8,
-  });
+  // マップのオプションを設定
+  const defaultLocation = { lat: 35.6809591, lng: 139.7673068 };
+  const mapOptions = {
+    center: { lat: defaultLocation.lat, lng: defaultLocation.lng },
+    zoom: 15,
+    streetViewControl: false, // ストリートビューのボタン非表示
+    mapTypeControl: false, // 地図、航空写真のボタン非表示
+    fullscreenControl: false, // フルスクリーンボタン非表示
+  };
+
+  // マップオブジェクトの作成
+  map = new Map(document.getElementById("create_map"), mapOptions);
 }
 
 initMap();

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -14,13 +14,20 @@
           <%= f.text_area :body, class: "textarea textarea-bordered", rows: 5 %>
         </div>
 
-        <%= f.hidden_field :distance, id: "course_distance_field" %>
-        <%= f.hidden_field :address, id: "course_address_field" %>
-        <%= f.hidden_field :encoded_polyline, id: "course_encoded_polyline_field" %>
-        <%= f.hidden_field :positions, id: "marker_positions_field" %>
+        <%= f.hidden_field :distance, id: "course_distance_field" %> <%# 距離を送信するためのフィールド %>
+        <%= f.hidden_field :address, id: "course_address_field" %> <%# コースの始点を送信するためのフィールド %>
+        <%= f.hidden_field :encoded_polyline, id: "course_encoded_polyline_field" %> <%# ポリラインデータを送信するためのフィールド %>
+        <%= f.hidden_field :positions, id: "marker_positions_field" %> <%# コースのマーカーの位置情報を送信するためのフィールド %>
 
         <%= f.submit "作成", class: "btn btn-accent" %>
       <% end %>
     </div>
+    <div class="col-span-2">
+      <div class="h-screen">
+        <div id="create_map" style="width: 100%; height: 100%;"></div>
+      </div>
+    </div>
   </div>
 </div>
+
+<%= javascript_include_tag "gmap", "data-turbo-track": "reload" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,1 @@
 <h1 class="text-4xl m-3">散歩コース共有アプリ</h1>
-
-<div class="h-screen">
-	<div id="map" style="width: 70%; height: 100%;"></div>
-</div>
-
-<%= javascript_include_tag "gmap", "data-turbo-track": "reload" %>


### PR DESCRIPTION
## 概要
コース作成画面にマップを表示しました

## 内容
`app/javascript/gmap.js`
- 以下の条件でマップオブジェクトを作成
  - 中央座標：東京駅
  - 以下のボタンを非表示
    - ストリートビュー
    - 地図・航空写真ボタン
    - フルスクリーンボタン

`app/views/courses/new.html.erb`
- 作成したマップオブジェクトを表示する領域を作成

## 確認
コース作成画面にマップが表示されていることを確認しました

## 参考文献
- [Google Maps/デフォルトUIを無効にする](https://developers.google.com/maps/documentation/javascript/controls?hl=ja)

Closes #27 