### PR TITLE
Add:作成したルートの情報をフォームに追加できるように変更

### DIFF
--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -1,10 +1,7 @@
 let map;
-let routePoints = [];
+let routePoints = []; // ルートを構成する座標データ
 let directionsService;
-let routePolyline;
-let totalDistance = 0;
-let startAddress;
-let encodedPolyline;
+let routePolyline; // ルートのポリラインオブジェクト
 
 async function initMap() {
   // 必要なライブラリをインポート
@@ -31,60 +28,74 @@ async function initMap() {
     if (!e.placeId) {
       routePoints.push(e.latLng);
     }
-    calcRoute();
-  });
 
-  // フォームに値を追加
-  addValueToForm();
+    if (routePoints.length >= 2) {
+      resetPolyline(routePolyline); // マップに描写されているポリラインを削除
+
+      calcRoute(routePoints) // ルートを計算
+        .then(route => {
+          const encodedPolyline = getEncodedPolyline(route); // ポリラインデータを取得
+          drawPolyline(encodedPolyline); // ポリラインをマップ上に描写
+          addValueToForm(route, routePoints); // フォームにデータを追加
+        });
+    }
+  });
 }
 
 initMap();
 
 // !ルート計算
-function calcRoute() {
-  if (routePoints.length < 2) {
+function calcRoute(routePoints) {
+  // ルートの条件
+  const start = routePoints[0];
+  const end = routePoints[routePoints.length - 1];
+  const waypts = routePoints.slice(1, -1).map(point => ({
+    location: point,
+    stopover: true,
+  }));
+  const request = {
+    origin: start,
+    destination: end,
+    waypoints: waypts,
+    travelMode: 'WALKING',
+  };
+
+  if (waypts.length > 10) {
     return;
-  } else {
-    resetPolyline(routePolyline); // ポリラインのリセット
-
-    // ルートの条件
-    const start = routePoints[0];
-    const end = routePoints[routePoints.length - 1];
-    const waypts = routePoints.slice(1, -1).map(point => ({
-      location: point,
-      stopover: true,
-    }));
-    const request = {
-      origin: start,
-      destination: end,
-      waypoints: waypts,
-      travelMode: 'WALKING',
-    };
-
-    // 計算
-    if (waypts.length > 10) {
-      return;
-    } else {
-      directionsService.route(request, (response, status) => {
-        if (status == 'OK') {
-          const route = response.routes[0]; // ルート計算の結果からルート情報を取得
-          encodedPolyline = route.overview_polyline; // ルートのポリラインデータを取得
-          drawPolyline(encodedPolyline);
-          calcTotalDistance(route);
-          startAddress = route.legs[0].start_address; // ルートの始点の住所を取得
-        }
-      });
-    }
   }
+  
+  // 計算
+  return new Promise((resolve) => {
+    directionsService.route(request, (response, status) => {
+      if (status == 'OK') {
+        const route = response.routes[0]; // ルート計算の結果からルート情報を取得
+        resolve(route);
+      }
+    });
+  })
 }
 window.calcRoute = calcRoute;
+
+// !ポリラインデータを取得
+function getEncodedPolyline(route) {
+  const encodedPolyline = route.overview_polyline; // ルートのポリラインデータを取得
+  
+  return encodedPolyline;
+}
+window.getEncodedPolyline = getEncodedPolyline;
 
 // !ポリラインデータをマップ上に描写
 function drawPolyline(encodedPolyline) {
   const routeCoordinates = google.maps.geometry.encoding.decodePath(encodedPolyline); // エンコードされたパスをデコード
 
-  // ポリラインオブジェクトの作成
-  routePolyline = new google.maps.Polyline({
+  routePolyline = getPolylineObject(routeCoordinates); // ポリラインオブジェクトを作成
+  routePolyline.setMap(map);
+}
+window.drawPolyline = drawPolyline;
+
+// !ポリラインオブジェクトの作成
+function getPolylineObject(routeCoordinates) {
+  const polylineObject = new google.maps.Polyline({
     path: routeCoordinates,
     geodesic: true, // 地球の曲率を考慮した直線
     strokeColor: "#ff7f50", // ポリラインの色
@@ -92,9 +103,9 @@ function drawPolyline(encodedPolyline) {
     strokeWeight: 7, // ポリラインの太さ
   });
 
-  routePolyline.setMap(map);
+  return polylineObject;
 }
-window.drawPolyline = drawPolyline;
+window.getPolylineObject = getPolylineObject;
 
 // !ポリラインをマップ上から除去
 function resetPolyline(routePolyline) {
@@ -107,28 +118,37 @@ window.resetPolyline = resetPolyline;
 
 // !ルートの総距離を計算
 function calcTotalDistance(route) {
+  let totalDistance = 0;
+
   route.legs.forEach((leg) => {
     totalDistance += leg.distance.value / 1_000; // 総距離kmを算出
   });
+
+  return totalDistance;
 }
 window.calcTotalDistance = calcTotalDistance;
 
 // !フォームに値を追加
-function addValueToForm() {
+function addValueToForm(route, routePoints) {
   const form = document.getElementById("course-form");
-  form.addEventListener('submit', (e) => {
-    // コースの距離
-    const distanceField = e.target.querySelector('#course-distance-field');
-    distanceField.value = totalDistance;
-
-    // コースの始点の住所
-    const addressField = e.target.querySelector('#course-address-field');
-    addressField.value = startAddress;
-    
-    // ポリラインデータ
-    const encodedPolylineField = e.target.querySelector('#course-encoded-polyline-field');
-    encodedPolylineField.value = encodedPolyline;
-    // console.log(e.target);
-  })
+  if (form) {
+    form.addEventListener('submit', (e) => {
+      // コースの距離
+      const distanceField = e.target.querySelector('#course-distance-field');
+      distanceField.value = calcTotalDistance(route);
+  
+      // コースの始点の住所
+      const addressField = e.target.querySelector('#course-address-field');
+      addressField.value = route.legs[0].start_address;
+      
+      // ポリラインデータ
+      const encodedPolylineField = e.target.querySelector('#course-encoded-polyline-field');
+      encodedPolylineField.value = getEncodedPolyline(route);
+  
+      // コースを構成する座標データ
+      const positionsField = e.target.querySelector('#marker-positions-field');
+      positionsField.value = JSON.stringify(routePoints);
+    })
+  }
 }
 window.addValueToForm = addValueToForm;

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -1,7 +1,8 @@
 let map;
-let route_points = [];
+let routePoints = [];
 let directionsService;
 let routePolyline;
+let totalDistance = 0;
 
 async function initMap() {
   // 必要なライブラリをインポート
@@ -21,30 +22,33 @@ async function initMap() {
   };
 
   // マップオブジェクトの作成
-  map = new Map(document.getElementById("create_map"), mapOptions);
+  map = new Map(document.getElementById("create-map"), mapOptions);
 
   // マップをクリックした時の動作
   map.addListener('click', (e) => {
     if (!e.placeId) {
-      route_points.push(e.latLng);
+      routePoints.push(e.latLng);
     }
     calcRoute();
   });
+
+  // フォームに値を追加
+  addValueToForm();
 }
 
 initMap();
 
-// ルート計算
+// !ルート計算
 function calcRoute() {
-  if (route_points.length < 2) {
+  if (routePoints.length < 2) {
     return;
   } else {
     resetPolyline(routePolyline); // ポリラインのリセット
 
     // ルートの条件
-    const start = route_points[0];
-    const end = route_points[route_points.length - 1];
-    const waypts = route_points.slice(1, -1).map(point => ({
+    const start = routePoints[0];
+    const end = routePoints[routePoints.length - 1];
+    const waypts = routePoints.slice(1, -1).map(point => ({
       location: point,
       stopover: true,
     }));
@@ -64,6 +68,7 @@ function calcRoute() {
           const route = response.routes[0]; // ルート計算の結果からルート情報を取得
           const encodedPolyline = route.overview_polyline; // ルートのポリラインデータを取得
           drawPolyline(encodedPolyline);
+          calcTotalDistance(route);
         }
       });
     }
@@ -71,7 +76,7 @@ function calcRoute() {
 }
 window.calcRoute = calcRoute;
 
-// ポリラインデータをマップ上に描写
+// !ポリラインデータをマップ上に描写
 function drawPolyline(encodedPolyline) {
   const routeCoordinates = google.maps.geometry.encoding.decodePath(encodedPolyline); // エンコードされたパスをデコード
 
@@ -88,7 +93,7 @@ function drawPolyline(encodedPolyline) {
 }
 window.drawPolyline = drawPolyline;
 
-// ポリラインをマップ上から除去
+// !ポリラインをマップ上から除去
 function resetPolyline(routePolyline) {
   if (routePolyline) {
     routePolyline.setMap(null);
@@ -96,3 +101,27 @@ function resetPolyline(routePolyline) {
   }
 }
 window.resetPolyline = resetPolyline;
+
+// !ルートの総距離を計算
+function calcTotalDistance(route) {
+  route.legs.forEach((leg) => {
+    totalDistance += leg.distance.value / 1_000; // 総距離kmを算出
+  });
+}
+window.calcTotalDistance = calcTotalDistance;
+
+// !フォームに値を追加
+function addValueToForm() {
+  const form = document.getElementById("course-form");
+  form.addEventListener('submit', (e) => {
+    // コースの距離
+    const distanceField = e.target.querySelector('#course-distance-field');
+    distanceField.value = totalDistance;
+
+    // コースの始点の住所
+    const addressField = e.target.querySelector('#course-address-field');
+    // addressField.value = 
+    // console.log(e.target);
+  })
+}
+window.addValueToForm = addValueToForm;

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -3,6 +3,7 @@ let routePoints = [];
 let directionsService;
 let routePolyline;
 let totalDistance = 0;
+let startAddress;
 
 async function initMap() {
   // 必要なライブラリをインポート
@@ -69,6 +70,7 @@ function calcRoute() {
           const encodedPolyline = route.overview_polyline; // ルートのポリラインデータを取得
           drawPolyline(encodedPolyline);
           calcTotalDistance(route);
+          startAddress = route.legs[0].start_address; // ルートの始点の住所を取得
         }
       });
     }
@@ -120,7 +122,7 @@ function addValueToForm() {
 
     // コースの始点の住所
     const addressField = e.target.querySelector('#course-address-field');
-    // addressField.value = 
+    addressField.value = startAddress;
     // console.log(e.target);
   })
 }

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -4,6 +4,7 @@ let directionsService;
 let routePolyline;
 let totalDistance = 0;
 let startAddress;
+let encodedPolyline;
 
 async function initMap() {
   // 必要なライブラリをインポート
@@ -67,7 +68,7 @@ function calcRoute() {
       directionsService.route(request, (response, status) => {
         if (status == 'OK') {
           const route = response.routes[0]; // ルート計算の結果からルート情報を取得
-          const encodedPolyline = route.overview_polyline; // ルートのポリラインデータを取得
+          encodedPolyline = route.overview_polyline; // ルートのポリラインデータを取得
           drawPolyline(encodedPolyline);
           calcTotalDistance(route);
           startAddress = route.legs[0].start_address; // ルートの始点の住所を取得
@@ -123,6 +124,10 @@ function addValueToForm() {
     // コースの始点の住所
     const addressField = e.target.querySelector('#course-address-field');
     addressField.value = startAddress;
+    
+    // ポリラインデータ
+    const encodedPolylineField = e.target.querySelector('#course-encoded-polyline-field');
+    encodedPolylineField.value = encodedPolyline;
     // console.log(e.target);
   })
 }

--- a/app/views/courses/new.html.erb
+++ b/app/views/courses/new.html.erb
@@ -3,7 +3,7 @@
 
   <div class="grid grid-cols-3 gap-4">  
     <div class="col-span-1">
-      <%= form_with model: @course_marker_form, url: courses_path, method: :post, local: true do |f| %>
+      <%= form_with model: @course_marker_form, url: courses_path, method: :post, local: true, id: "course-form" do |f| %>
         <div class="mb-3">
           <%= f.label :title, class: "label" %>
           <%= f.text_field :title, autofocus: true, class: "input input-bordered" %>
@@ -14,17 +14,17 @@
           <%= f.text_area :body, class: "textarea textarea-bordered", rows: 5 %>
         </div>
 
-        <%= f.hidden_field :distance, id: "course_distance_field" %> <%# 距離を送信するためのフィールド %>
-        <%= f.hidden_field :address, id: "course_address_field" %> <%# コースの始点を送信するためのフィールド %>
-        <%= f.hidden_field :encoded_polyline, id: "course_encoded_polyline_field" %> <%# ポリラインデータを送信するためのフィールド %>
-        <%= f.hidden_field :positions, id: "marker_positions_field" %> <%# コースのマーカーの位置情報を送信するためのフィールド %>
+        <%= f.hidden_field :distance, id: "course-distance-field" %> <%# 距離を送信するためのフィールド %>
+        <%= f.hidden_field :address, id: "course-address-field" %> <%# コースの始点を送信するためのフィールド %>
+        <%= f.hidden_field :encoded_polyline, id: "course-encoded-polyline-field" %> <%# ポリラインデータを送信するためのフィールド %>
+        <%= f.hidden_field :positions, id: "marker-positions-field" %> <%# コースのマーカーの位置情報を送信するためのフィールド %>
 
         <%= f.submit "作成", class: "btn btn-accent" %>
       <% end %>
     </div>
     <div class="col-span-2">
       <div class="h-screen">
-        <div id="create_map" style="width: 100%; height: 100%;"></div>
+        <div id="create-map" style="width: 100%; height: 100%;"></div>
       </div>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,11 +3,12 @@
   <head>
     <title>Myapp</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
 
     <%# gem gonの設定 %>
     <%= Gon::Base.render_data %>
+
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>


### PR DESCRIPTION
## 概要
コース作成機能を実装するため、コースのデータを取得し、フォームに値を追加する処理を実装しました

## 内容
`app/javascript/gmap.js`
### データを取得
- コースの総距離
  - コースの計算結果からコースの情報 (`DirectionsRoute`オブジェクト) を取得し、さらに各区間の情報 (`DirectionsLeg`オブジェクト) から距離を取得
  - `calcTotalDistance`関数を定義し、処理を追加
- コースの始点の住所
  - コースの情報から最初の区間 (legs[0]) のスタート地点の住所を取得
- コースのポリラインデータ
  - コースの情報からエンコードされたポリラインデータを取得
- コースを構成する座標
  - 作成した`routePoints`配列

### フォームにデータを追加
- `addValueToForm`関数を定義し、下記のフォームに取得した値を追加
  - distance：距離
  - address：住所
  - encoded_polyline：ポリラインデータ
  - positions：コースを構成する座標

### コース作成に関する関数のリファクタリング

## 確認
- コース作成ボタンをクリックした時、データがcoursesおよびmarkersテーブルに保存されることを確認しました

## 参考文献

Closes #74 