### PR TITLE
Add:コース詳細用のマップを作成

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -24,6 +24,13 @@ class CoursesController < ApplicationController
 
   def show
     @course = Course.find(params[:id])
+
+    gon.google_map_id = Rails.application.credentials.google_maps_mapId
+    gon.course_encoded_polyline = @course.encoded_polyline
+    gon.start_position = {
+      lat: @course.markers[0].location.latitude,
+      lng: @course.markers[0].location.longitude,
+    }
   end
 
   private

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -29,7 +29,7 @@ class CoursesController < ApplicationController
     gon.course_encoded_polyline = @course.encoded_polyline
     gon.start_position = {
       lat: @course.markers[0].location.latitude,
-      lng: @course.markers[0].location.longitude,
+      lng: @course.markers[0].location.longitude
     }
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,5 @@
 class CoursesController < ApplicationController
-  skip_before_action :authenticate_user!, only: %i[index]
+  skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
     @courses = Course.includes(:user)

--- a/app/forms/course_marker_form.rb
+++ b/app/forms/course_marker_form.rb
@@ -19,7 +19,7 @@ class CourseMarkerForm
     course = Course.new(title: title, body: body, distance: distance, address: address, encoded_polyline: encoded_polyline, user_id: user_id)
     if course.save
       positions.each_with_index do |position, index|
-        location = "POINT(#{position['lat']} #{position['lng']})"
+        location = "POINT(#{position['lng']} #{position['lat']})"
         Marker.create(location: location, order: index, course_id: course.id)
       end
       course.id

--- a/app/javascript/show_gmap.js
+++ b/app/javascript/show_gmap.js
@@ -1,0 +1,38 @@
+let show_map;
+let googleMapId = gon.google_map_id;
+let courseEncodedPolyline = gon.course_encoded_polyline;
+let startPosition = gon.start_position;
+
+async function initMap() {
+  // 必要なライブラリをインポート
+  const { Map } = await google.maps.importLibrary("maps");
+  const {encoding} = await google.maps.importLibrary("geometry");
+  const {Polyline} = await google.maps.importLibrary("maps")
+
+  // マップのオプションを設定
+  const mapOptions = {
+    center: { lat: startPosition.lat, lng: startPosition.lng },
+    zoom: 17,
+    streetViewControl: false, // ストリートビューのボタン非表示
+    mapTypeControl: false, // 地図、航空写真のボタン非表示
+    fullscreenControl: false, // フルスクリーンボタン非表示
+    mapId: googleMapId,
+  };
+
+  // マップオブジェクトの作成
+  show_map = new Map(document.getElementById("show-map"), mapOptions);
+
+  // ポリラインオブジェクトを作成し、コースをマップに描写
+  const routeCoordinates = new encoding.decodePath(courseEncodedPolyline);
+
+  const routePolyline = new Polyline({
+    path: routeCoordinates,
+    geodesic: true,
+    strokeColor: "#ff7f50",
+    strokeOpacity: 0.9,
+    strokeWeight: 7,
+  });
+  routePolyline.setMap(show_map);
+}
+
+initMap();

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -13,6 +13,11 @@
     <div class="grid grid-cols-4 gap-2">
       <%= image_tag "course_placeholder.png" %>
     </div>
+    <div class="h-96">
+      <div id="show-map" style="width: 100%; height: 100%;"></div>
+    </div>
     <p><%= @course.body %></p>
   </div>
 </div>
+
+<%= javascript_include_tag "show_gmap", "data-turbo-track": "reload" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,9 +4,6 @@
     <title>Myapp</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
-    <%# gem gonの設定 %>
-    <%= Gon::Base.render_data %>
-
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
@@ -28,6 +25,9 @@
 
     <%# フラッシュメッセージ %>
     <%= render 'shared/flash_message' %>
+
+    <%# gem gonの設定 %>
+    <%= Gon::Base.render_data %>
 
     <%= yield %>
 


### PR DESCRIPTION
## 概要
コース詳細機能を実装するため、マップを作成し、コースを表示できるようにしました。

## 内容
### マップおよびコースの作成
`app/javascript/show_gmap.js`
- 以下のライブラリをインポート
  - maps
  - geometry
- gem gonから渡されたコースのデータを用いてマップおよびポリラインオブジェクトを作成
  - マップオブジェクトの作成
    - 中心：コースの始点
  - ポリラインオブジェクトの作成
- `app/views/courses/show.html.erb`に作成したマップを表示する領域を作成

### gem gonで設定した変数をJSへ渡すタイミングを修正
- ページが読み込まれた後、設定されたデータを使用できるようにするため、以下の記述を`head`タグ内から`body`タグ内に変更
```ruby
<%= Gon::Base.render_data %>
```

### コースを構成する座標が正しいデータで保存されるように修正
`app/forms/course_marker_form.rb`
- PostGISでは座標データが経度 (longitude)、緯度 (latitude) の順番で保存されるが、Markerモデルの座標データ (location) では緯度経度の順番になっていたため、経度緯度の順で保存されるように修正

## 確認
コース詳細画面にマップおよび作成したコースが表示されることを確認しました。

Closes #34 