### PR TITLE
[Feature] Swiperを導入し、画像をスライド形式で表示

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,18 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
+
+// import Swiper JS
+import Swiper from "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.mjs";
+// init Swiper
+document.addEventListener("turbo:load", () => {
+  const swiper = new Swiper('.swiper', {  
+    navigation: {
+      nextEl: ".swiper-button-next",
+      prevEl: ".swiper-button-prev",
+    },
+    pagination: {
+      el: ".swiper-pagination",
+    },
+  });
+});

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -2,7 +2,18 @@
   <div class="card card-compact bg-base-100 w-72 shadow-xl my-3">
     <figure>
       <% if course.main_images.attached? %>
-        <%= image_tag course.main_images.first.variant(:thumb).processed, class: "rounded-xl" %>
+        <div class="swiper">
+          <div class="swiper-wrapper">
+            <% course.main_images.each do |image| %>
+              <div class="swiper-slide"><%= image_tag image.variant(:thumb).processed, class: "rounded-xl" %></div>
+            <% end %>
+          </div>
+          <%# navigation buttons %>
+          <div class="swiper-button-next"></div>
+          <div class="swiper-button-prev"></div>
+          <%# pagination %>
+          <div class="swiper-pagination"></div>
+        </div>
       <% else %>
         <%= image_tag "course_placeholder.png", class: "rounded-xl" %>
       <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,8 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= stylesheet_link_tag "https://fonts.googleapis.com/icon?family=Material+Icons", "data-turbo-track": "reload" %>
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" rel="stylesheet">
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
 


### PR DESCRIPTION
## 概要
Swiperを導入し、コース一覧画面における各コースの画像をスライド表示できるようにしました

## 内容
### Swiperの導入
- Swiperのスタイルシートを導入
``` html
<!-- app/views/layouts/application.html.erb -->
<link href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css" rel="stylesheet">
```
- SwiperのJSファイルを導入
``` javascript
// app/javascripts/application.js
import Swiper from "https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.mjs";
```

### Swiperのセットアップ
- `app/javascripts/application.js`を編集し、Swiperの初期化およびオプション (スライドの設定) を定義

### ビューにSwiperの要素を追加
`app/views/courses/_course.html.erb`
- Swiperの要素を追加
- ページネーションおよびナビゲーションの要素を追加

## 確認
- 複数のファイルが添付されているとき、コース一覧の画像がスライド形式で表示されることを確認しました
[![Image from Gyazo](https://i.gyazo.com/f3c5733203781b115210c6876631d152.png)](https://gyazo.com/f3c5733203781b115210c6876631d152)

## 参考文献
- https://swiperjs.com/get-started

Closes #116 