### PR TITLE
Fix/google oauth model

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -40,6 +40,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   protected
 
+  def build_resource(hash = {})
+    # ユーザーオブジェクト作成時、uidに一意な値を設定
+    hash[:uid] = SecureRandom.uuid
+    super
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
   def configure_sign_up_params
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])

--- a/db/migrate/20250220131601_add_omniauth_to_users.rb
+++ b/db/migrate/20250220131601_add_omniauth_to_users.rb
@@ -2,5 +2,7 @@ class AddOmniauthToUsers < ActiveRecord::Migration[7.0]
   def change
     add_column :users, :provider, :string
     add_column :users, :uid, :string
+
+    add_index :users, [:uid, :provider], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,6 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_02_20_131601) do
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
## 概要
通常サインアップ時、uidに一意な値を設定できるようにしました

## 問題点
OAuth認証を用いず、emailによって通常サインアップさせる場合、uidに一意制約を設けているため、一意なランダムな値を設定する必要性があった

## 内容
- マイグレーションファイルを編集し、usersテーブルのuidとproviderカラムに一意制約を追加
``` bash
rails db:rollback STEP=1
rails db:migrate
```
- ユーザーオブジェクト作成時、uidに一意な値を追加できるように、`app/controllers/devise/registrations_controller.rb`の`build_resource`メソッドをオーバーライド

Fixes #93 