### PR TITLE
[Feature] Google認証のコールバック処理を追加

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  # You should configure your model like this:
-  # devise :omniauthable, omniauth_providers: [:twitter]
+  def google_oauth2
+    @user = User.from_omniauth(request.env['omniauth.auth'])
 
-  # You should also create an action method in this controller like this:
-  # def twitter
-  # end
+    if @user.persisted?
+      flash[:notice] = t('devise.omniauth_callbacks.success', kind: 'Google')
+      sign_in_and_redirect @user, event: :authentication
+    else
+      # 認証情報をセッションに保存
+      session['devise.google_data'] = request.env['omniauth.auth'].except('extra')
+      redirect_to new_user_registration_url, error: t('devise.omniauth_callbacks.failure', kind: 'Google')
+    end
+  end
 
   # More info at:
   # https://github.com/heartcombo/devise#omniauth
@@ -21,10 +27,15 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   #   super
   # end
 
-  # protected
+  protected
+
+  def after_sign_in_path_for(_resource)
+    courses_path
+  end
 
   # The path used when OmniAuth fails
   # def after_omniauth_failure_path_for(scope)
   #   super(scope)
   # end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,30 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }
   validates :uid, uniqueness: { scope: :provider }
 
+  # ユーザー自身のオブジェクトか確認するメソッド
   def own?(object)
     id == object&.user_id
+  end
+
+  # 
+  def self.from_omniauth(auth)
+    user = User.where(uid: auth.uid, provider: auth.provider).first
+  
+    unless user
+        user = User.create(
+          name: auth.info.name,
+          uid: auth.uid,
+          provider: auth.provider,
+          email: User.dummy_email(auth),
+          password: Devise.friendly_token[0,20]
+        )
+    end
+    user
+  end
+
+  private
+
+  def self.dummy_email(auth)
+    "#{auth.uid}-#{auth.provider}@example.com"
   end
 end

--- a/config/locales/devise/devise.views.ja.yml
+++ b/config/locales/devise/devise.views.ja.yml
@@ -74,7 +74,7 @@ ja:
         message: ログイン失敗が繰り返されたため、アカウントはロックされています。
         subject: アカウントのロック解除について
     omniauth_callbacks:
-      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      failure: "%{kind} アカウントによる認証に失敗しました。"
       success: "%{kind} アカウントによる認証に成功しました。"
     passwords:
       edit:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: 'users/registrations',
-    sessions: 'users/sessions'
+    sessions: 'users/sessions',
+    omniauth_callbacks: 'users/omniauth_callbacks'
   }, skip: [:registrations]
   devise_scope :user do
     get 'signup', to: 'users/registrations#new', as: :new_user_registration


### PR DESCRIPTION
## 概要
Googleログイン機能を実装するため、Googleから返されたデータを処理するコールバックを追加しました

## 内容
### ルーティング
- コールバック用のルーティングを定義
``` ruby
devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
```

### コントローラ
`app/controllers/users/omniauth_callbacks_controller.rb`
- Googleから返されたデータを以下のように処理
  - ユーザーを取得 or 存在しない場合は下記のようにユーザーを作成
    - name：Googleから取得したデータ
    - uid：Googleから取得したデータ
    - provider：Googleから取得したデータ
    - email：ダミーのメールアドレス
    - password：適当に生成したパスワード
  - ユーザーがDBに存在することを確認
    - 成功時：ログイン後、コース一覧画面へリダイレクト
    - 失敗時：セッションに認証情報を保持し、ユーザー登録画面へリダイレクト

## 確認
Googleから取得した情報がDBに保存され、会員登録・ログインできることを確認しました

Closes #94 