### PR TITLE
Fix:OGP用metaタグのimage属性に設定されるurlを修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -18,7 +18,7 @@ module ApplicationHelper
         local: "ja-JP" # 言語と地域
       },
       twitter: {
-        card: "summary_large_image",
+        card: "summary",
         # image: image_url('default_share.png')
       }
     }

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -3,6 +3,7 @@ class Course < ApplicationRecord
   has_many :markers, dependent: :destroy
   has_many_attached :main_images do |attachable|
     attachable.variant :thumb, resize_to_fill: [300, 200]
+    attachable.variant :twitter_card, resize_to_limit: [800, 800]
   end
 
   validates :title, presence: true

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,4 +1,4 @@
-<% assign_meta_tags title: @course.title, description: @course.body, image: url_for(@course.main_images[0]) %>
+<% assign_meta_tags title: @course.title, description: @course.body, image: rails_blob_url(@course.main_images[0].variant(:twitter_card).processed) %>
 
 <div class="container mx-auto pt-4 px-4">
   <h1><%= t('.title') %></h1>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,6 +64,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "myapp_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: "path-finder-43182-883c012d073e.herokuapp.com" }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
## 概要
OGP用のmetaタグの内image属性に設定されるurlを完全なurlに修正

## 内容

Fixes #190 