### PR TITLE
[Feature] コース検索用のフォームオブジェクトを作成

### DIFF
--- a/app/forms/search_courses_form.rb
+++ b/app/forms/search_courses_form.rb
@@ -1,0 +1,9 @@
+class SearchCoursesForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :title, :string
+  attribute :body, :string
+  attribute :distance, :decimal
+  attribute :location, :string
+end

--- a/app/forms/search_courses_form.rb
+++ b/app/forms/search_courses_form.rb
@@ -2,8 +2,26 @@ class SearchCoursesForm
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  attribute :title, :string
-  attribute :body, :string
-  attribute :distance, :decimal
-  attribute :location, :string
+  attribute :course_query, :string
+  attribute :distance, :integer
+
+  def search
+    relation = Course.distinct
+
+    course_query_words.each do |word|
+      relation = relation.title_contain(word)
+      relation = relation.body_contain(word)
+      relation = relation.address_contain(word)
+    end
+
+    relation = relation.distance_within_limit(distance) if distance.present?
+
+    relation
+  end
+
+  private
+
+  def course_query_words
+    course_query.present? ? course_query.split(nil) : []
+  end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -12,4 +12,9 @@ class Course < ApplicationRecord
   validates :address, length: { maximum: 255 }
   validates :encoded_polyline, presence: true, length: { maximum: 255 }
   validates :main_images, attachment: { purge: true, content_type: %r{\Aimage/(png|jpeg)\Z}, maximum: 5_242_880 }
+
+  scope :title_contain, ->(word) { where('title LIKE ?', "%#{word}%") }
+  scope :body_contain, ->(word) { where('body LIKE ?', "%#{word}%") }
+  scope :address_contain, ->(word) { where('address LIKE ?', "%#{word}%") }
+  scope :distance_within_limit, ->(distance) { where('distance <= ?', distance) }
 end


### PR DESCRIPTION
## 概要
コース検索機能を実装するため、検索用のform objectを作成しました

## 内容
### 検索条件
- コースのタイトル：:title, 部分一致
- コースの内容：:body, 部分一致
- コースの距離：:distance, 指定距離以下
- コースの所在地：:address, 部分一致

### 実装
- フォームオブジェクト`SearchCoursesForm`を作成し、属性を定義
  - `course_query`：title, body, address用の属性
  - `distance`：distance用の属性
- Courseモデルで上記検索条件でスコープを定義
- フォームオブジェクトで検索用のメソッドを定義

Closes #151 