### PR TITLE
[Feature] 独自ドメインの設定

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,7 +64,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "myapp_production"
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: "path-finder-43182-883c012d073e.herokuapp.com" }
+  config.action_mailer.default_url_options = { host: "www.xn--t8jvn5b0a8338dmth.com" }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
@@ -92,4 +92,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Set custom domain
+  config.hosts << "www.xn--t8jvn5b0a8338dmth.com"
 end


### PR DESCRIPTION
## 概要
独自ドメインを取得し、Herokuに追加しました

## 内容
- お名前.comで独自ドメイン「お散歩マップ.com」を取得
- 以下のコマンドを実行し、Herokuに独自ドメイン (日本語部分はPunycodeに変換) を追加
``` bash
heroku domains:add www.xn--t8jvn5b0a8338dmth.com
```
- お名前.comでDNS (CNAME) レコードにHerokuのターゲットDNSを設定
(ドメイン設定 > DNS設定 > DNSレコードを設定する)
- `config/environments/production.rb`を編集し、アプリケーションが許可するホストに独自ドメインを追加
- Google Maps APIで許可するwebサイトを変更

## 確認
以下のコマンドを実行し、DNSが正しく設定されていることを確認しました
``` bash
host www.xn--t8jvn5b0a8338dmth.com
```

##  参考文献
- https://devcenter.heroku.com/ja/articles/custom-domains

Closes #105 