### PR TITLE
[Feature] リクエストスペックの実装

### DIFF
--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -6,5 +6,14 @@ FactoryBot.define do
     address { "address" }
     encoded_polyline { "encoded_polyline_string" }
     association :user
+
+    trait :invalid do
+      title { "" }
+      encoded_polyline { "" }
+    end
+
+    trait :show do
+      title { "Show" }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,11 @@ FactoryBot.define do
     password { "password" }
     password_confirmation { "password" }
     uid { SecureRandom.uuid }
+
+    trait :invalid do
+      name { nil }
+      email { nil }
+      password { nil }
+    end
   end
 end

--- a/spec/requests/courses_spec.rb
+++ b/spec/requests/courses_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe "CoursesController", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    post user_session_path, params: { user: { email: user.email, password: user.password } }
+  end
+
+  describe "GET #index" do
+    it "リクエストが成功すること" do
+      get courses_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "GET #new" do
+    it "リクエストが成功すること" do
+      get new_course_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "POST #create" do
+    let(:positions) { [{ lat: 35.68291089208541, lng: 139.76012256480192 }, { lat: 35.681307393562676, lng: 139.75896196093043 }] }
+
+    context "パラメータが妥当な場合" do
+      it "リクエストが成功すること" do
+        post courses_path, params: { course_marker_form: attributes_for(:course).merge(positions: positions.to_json) }
+        expect(response).to have_http_status(302)  
+      end
+
+      it "コースが登録されること" do
+        expect do
+          post courses_path, params: { course_marker_form: attributes_for(:course).merge(positions: positions.to_json) }
+        end.to change(Course, :count).by(1)
+      end
+
+      it "マーカーが2つ登録されること" do
+        expect do
+          post courses_path, params: { course_marker_form: attributes_for(:course).merge(positions: positions.to_json) }
+        end.to change(Marker, :count).by(2)
+      end
+
+      it "リダイレクトされること" do
+        post courses_path, params: { course_marker_form: attributes_for(:course).merge(positions: positions.to_json) }
+        expect(response).to redirect_to Course.last
+      end
+    end
+
+    context "パラメータが妥当でない場合" do
+      it "リクエストが失敗すること" do
+        post courses_path, params: { course_marker_form: attributes_for(:course, :invalid) }
+        expect(response).to have_http_status(422)
+      end
+
+      it "コースが登録されないこと" do
+        expect do
+          post courses_path, params: { course_marker_form: attributes_for(:course, :invalid) }
+        end.not_to change(Course, :count)
+      end
+
+      it "マーカーが登録されないこと" do
+        expect do
+          post courses_path, params: { course_marker_form: attributes_for(:course, :invalid) }
+        end.not_to change(Marker, :count)
+      end
+
+      it "エラーメッセージが表示されること" do
+        post courses_path, params: { course_marker_form: attributes_for(:course, :invalid) }
+        expect(response.body).to include "コースを作成できませんでした"
+      end
+    end
+  end
+
+  describe "GET #show" do
+    context "コースが存在する場合" do
+      let(:positions) { [{ lat: 35.68291089208541, lng: 139.76012256480192 }, { lat: 35.681307393562676, lng: 139.75896196093043 }] }
+      before do
+        post courses_path, params: { course_marker_form: attributes_for(:course, :show).merge(positions: positions.to_json) }
+      end
+
+      it "リクエストが成功すること" do
+        get course_path Course.last.id
+        expect(response).to have_http_status(200)
+      end
+
+      it "コース名が表示されていること" do
+        get course_path Course.last.id
+        expect(response.body).to include "Show"
+      end
+    end
+
+    context "コースが存在しない場合" do
+      xit "エラーが発生すること" do
+        expect { get course_path 1 }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:positions) { [{ lat: 35.68291089208541, lng: 139.76012256480192 }, { lat: 35.681307393562676, lng: 139.75896196093043 }] }
+    before do
+      post courses_path, params: { course_marker_form: attributes_for(:course).merge(positions: positions.to_json) }
+    end
+    
+    it "リクエストが成功すること" do
+      delete course_path Course.last
+      expect(response).to have_http_status(303)
+    end
+    
+    it "コースが削除されること" do
+      expect do
+        delete course_path Course.last
+      end.to change(Course, :count).by(-1)
+    end
+    
+    it "マーカーが2つ削除されること" do
+      expect do
+        delete course_path Course.last
+      end.to change(Marker, :count).by(-2)
+    end
+    
+    it "リダイレクトされること" do
+      delete course_path Course.last
+      expect(response).to redirect_to courses_path
+    end
+  end
+  
+  describe "GET #search" do
+    it "リクエストが成功すること"
+  end
+end

--- a/spec/requests/homes_spec.rb
+++ b/spec/requests/homes_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "HomesController", type: :request do
+  describe "GET /" do
+    it "リクエストが成功すること" do
+      get root_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe "Users::RegistrationsController", type: :request do
+  describe "GET #new" do
+    it "リクエストが成功すること" do
+      get new_user_registration_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "POST #create" do
+    context "パラメータが妥当な場合" do
+      it "リクエストが成功すること" do
+        post user_registration_path, params: { user: attributes_for(:user) }
+        expect(response).to have_http_status(303)
+      end
+      
+      it "ユーザーが登録されること" do
+        expect do
+          post user_registration_path, params: { user: attributes_for(:user) }
+        end.to change(User, :count).by(1)
+      end
+    end
+
+    context "パラメータが妥当でない場合" do
+      it "リクエストが失敗すること" do
+        post user_registration_path, params: { user: attributes_for(:user, :invalid) }
+        expect(response).to have_http_status(422)
+      end
+      
+      it "エラーメッセージが表示されること" do
+        post user_registration_path, params: { user: attributes_for(:user, :invalid) }
+        expect(response.body).to include "Eメールを入力してください"
+      end
+      
+      it "ユーザーが登録されないこと" do
+        expect do
+          post user_registration_path, params: { user: attributes_for(:user, :invalid) }
+        end.not_to change(User, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe "Users::SessionsController", type: :request do
+  describe "GET #new" do
+    it "リクエストが成功すること" do
+      get new_user_session_path
+      expect(response).to have_http_status(200)
+    end
+  end
+  
+  describe "POST #create" do
+    context "パラメータが妥当な場合" do
+      let(:user) { create(:user) }
+
+      it "リクエストが成功すること" do
+        post user_session_path, params: { user: { email: user.email, password: user.password } }
+        expect(response).to have_http_status(303)
+      end
+
+      it "リダイレクトすること" do
+        post user_session_path, params: { user: { email: user.email, password: user.password } }
+        expect(response).to redirect_to courses_path
+      end
+    end
+
+    context "パラメータが不正な場合" do
+      let(:user) { build(:user, email: "") }
+
+      it "リクエストが失敗すること" do
+        post user_session_path, params: { user: { email: user.email, password: user.password } }
+        expect(response).to have_http_status(422) 
+      end
+      
+      it "エラーメッセージが表示されること" do
+        post user_session_path, params: { user: { email: user.email, password: user.password } }
+        expect(response.body).to include "Eメールまたはパスワードが違います。" 
+      end
+    end
+  end
+  
+  describe "DELETE #destroy" do
+    let(:user) { create(:user) }
+  
+    it "リクエストが成功すること" do
+      post user_session_path, params: { user: { email: user.email, password: user.password } }
+      delete destroy_user_session_path
+      expect(response).to have_http_status(303)
+    end
+    
+    it "リダイレクトされること" do
+      post user_session_path, params: { user: { email: user.email, password: user.password } }
+      delete destroy_user_session_path
+      expect(response).to redirect_to courses_path
+    end
+  end
+end


### PR DESCRIPTION
## 概要
コントローラの機能をテストするため、リクエストスペックを実装しました

## 内容
リクエストスペック用のファイルを生成
``` bash
rails g rspec:request コントローラ名
```
  
以下の要件を満たすテストを作成
| Controller#Action | 条件 | 内容 |
|--------|--------|--------|
| home#index |  | リクエストが成功 |
| users/sessions#new |  | リクエストが成功 |
| users/sessions#create | パラメータが妥当 | リクエストが成功<br>リダイレクトされること |
|  | パラメータが妥当でない | リクエストが失敗<br>エラーメッセージが表示 | 
| users/sessions#destroy |  | リクエストが成功<br>リダイレクトされること |
| users/registrations#new |  | リクエストが成功 |
| users/registrations#create | パラメータが妥当 | リクエスト成功<br>ユーザーが作成される<br>リダイレクトされること |
|  | パラメータが妥当でない | リクエスト失敗<br>ユーザーが登録されない<br>エラーメッセージが表示 |
| courses#index<br>courses#new |  | リクエストが成功 |
| courses#create | パラメータが妥当 | リクエスト成功<br>コース・マーカーが登録<br>リダイレクトされること |
|  | パラメータが妥当でない | リクエスト失敗<br>コース・マーカーが登録されない<br>エラーメッセージが表示 |
| courses#show |  | リクエスト成功<br>作成したコースのタイトルが表示されること |
| courses#destroy |  | リクエスト成功<br>コースが削除されること<br>リダイレクトされること |

## 確認
作成したテストがパスすることを確認しました

Closes #200 