### PR TITLE
[Update]userモデルとlikeモデルの関連付けを修正

### DIFF
--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,13 +1,13 @@
 class LikesController < ApplicationController
   def create
-    like = current_user.likes.build(course_id: params[:course_id])
-    like.save
+    @course = Course.find(params[:course_id])
+    current_user.like(@course)
     redirect_to request.referer || courses_path
   end
 
   def destroy
-    like = Like.find(params[:id])
-    like.destroy!
+    @course = Like.find(params[:id]).course
+    current_user.unlike(@course)
     redirect_to request.referer || courses_path, status: :see_other
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -38,6 +38,7 @@ class Course < ApplicationRecord
   scope :distance_greater_than, ->(distance) { where(distance: distance..) }
   scope :distance_less_than, ->(distance) { where(distance: ..distance) }
 
+  # いいね機能に関するメソッド
   def liked_by?(user)
     likes.exists?(user_id: user&.id)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,6 +24,7 @@ class User < ApplicationRecord
 
   has_many :courses, dependent: :destroy
   has_many :likes, dependent: :destroy
+  has_many :liked_courses, through: :likes, source: :course
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :uid, uniqueness: { scope: :provider }
@@ -49,5 +50,14 @@ class User < ApplicationRecord
 
   def self.dummy_email(auth)
     "#{auth.uid}-#{auth.provider}@example.com"
+  end
+
+  # いいね機能に関するメソッド
+  def like(course)
+    liked_courses << course
+  end
+
+  def unlike(course)
+    liked_courses.destroy(course)
   end
 end


### PR DESCRIPTION
## 概要
UserモデルとLikeモデルの関連付けおよびlikesコントローラの処理を修正しました

## 内容
### 関連付け
- 下記のように関連付けを定義することで、ユーザーがいいねしたコースを直接参照することができるようにした
``` ruby
has_many :likes, dependent: :destroy # ユーザーが複数のいいねを持つことを定義

# ユーザーがlikeモデルを通して、courseモデルにアクセスすることを定義
# user.liked_coursesとすることであるユーザーがいいねしたコースを取得することができるようになる
has_many :liked_courses, through: :likes, source: :course
```

### インスタンスメソッド
- 上記で定義した関連付けを用いて、Userモデルに以下のメソッドを定義
  - コースをいいねするメソッド
  - コースからいいねを削除するメソッド

### likesコントローラの修正
上記で定義したメソッドを用いてcreateおよびdestroyアクションの処理を修正

Closes #232 