### PR TITLE
[Feature]コメント投稿用フォームをモーダルで表示

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,4 +1,9 @@
 class CommentsController < ApplicationController
+  def new
+    @comment = Comment.new
+    @course = Course.find(params[:course_id])
+  end
+
   def create
     @comment = current_user.comments.build(comment_params)
     @comment.save

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -25,7 +25,6 @@ class CoursesController < ApplicationController
   def show
     @course = Course.find(params[:id])
     set_course_data(@course)
-    @comment = Comment.new
     @comments = @course.comments.includes(:user).order(created_at: :desc)
   end
 

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,9 @@ application.register("courses", CoursesController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ModalController from "./modal_controller"
+application.register("modal", ModalController)
+
+import TabController from "./tab_controller"
+application.register("tab", TabController)

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="modal"
+export default class extends Controller {
+  static targets = ["modal"];
+
+  connect() {
+    // モーダルを開く動作
+    this.modalTarget.showModal();
+  }
+
+  // フォーム送信時に発火させるメソッド
+  close(event) {
+    // リクエストが成功したときtrueを返す
+    if (event.detail.success) {
+      this.modalTarget.close();
+    }
+  }
+  
+  // モーダルを閉じるメソッド
+  closeModal() {
+    this.modalTarget.close();
+  }
+}

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,7 +1,7 @@
-<%= form_with model: comment, url: course_comments_path(course), id: "comment-form" do |f| %>
-  <%= f.text_area :body, placeholder: t('courses.show.comment'), rows: 3, class: "textarea rounded-lg bg-slate-100 w-full" %>
-
-  <div class="flex justify-end">
-    <%= f.submit t('courses.show.comment_create'), class: "btn btn-primary rounded-lg text-white" %>
+<%= form_with model: comment, url: course_comments_path(course), id: "comment-form", data: { action: "turbo:submit-end->modal#close" } do |f| %>
+  <div class="mb-3">
+    <%= f.text_area :body, placeholder: t('courses.show.comment'), rows: 3, class: "textarea rounded-lg bg-slate-100 w-full" %>
   </div>
+
+  <%= f.submit t('courses.show.comment_create'), class: "btn btn-sm btn-primary rounded-lg text-white w-full" %>
 <% end %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -13,4 +13,17 @@
   <%= turbo_stream.replace "comment-form" do %>
     <%= render "form", comment: Comment.new, course: @comment.course %>
   <% end %>
+
+  <%# コメント数を更新 %>
+  <%= turbo_stream.replace "comment-size" do %>
+    <%= render "courses/comment_button", course: @comment.course %>
+  <% end %>
+
+  <%# タブの更新とアクティブなタグの切り替え %>
+  <%= turbo_stream.replace "comment-tab" do %>
+    <input type="radio" id="comment-tab" name="course_tabs" class="tab px-8" aria-label="コメント <%= @comment.course.comments.size %>件" checked />
+  <% end %>
+  <%= turbo_stream.replace "map-tab" do %>
+    <input type="radio" id="map-tab" name="course_tabs" class="tab px-8" aria-label="マップ" />
+  <% end %>
 <% end %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,1 +1,10 @@
+<%# コメント削除 %>
 <%= turbo_stream.remove "comment-#{ @comment.id }" %>
+
+<%# コメント数を更新 %>
+<%= turbo_stream.replace "comment-size" do %>
+  <%= render "courses/comment_button", course: @comment.course %>
+<% end %>
+<%= turbo_stream.replace "comment-tab" do %>
+  <input type="radio" id="comment-tab" name="course_tabs" class="tab px-8" aria-label="コメント <%= @comment.course.comments.size %>件" checked />
+<% end %>

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,0 +1,14 @@
+<%= turbo_frame_tag "modal" do %>
+  <dialog class="modal sm:modal-middle" data-controller="modal" data-modal-target="modal">
+    <div class="modal-box">
+      <div class="flex justify-end">
+        <div class="btn btn-sm btn-circle btn-ghost" data-action="click->modal#closeModal">
+          <span class="material-icons">close</span>
+        </div>
+      </div>
+      <div class="m-4">
+        <%= render "comments/form", comment: @comment, course: @course %>
+      </div>
+    </div>
+  </dialog>
+<% end %>

--- a/app/views/courses/_comment_button.html.erb
+++ b/app/views/courses/_comment_button.html.erb
@@ -1,0 +1,17 @@
+<div id="comment-size">
+  <% if user_signed_in? %>
+    <%= link_to new_course_comment_path(course), data: { turbo_frame: "modal" }, title: "コメントを投稿" do %>
+      <div class="flex items-end text-gray-400">
+        <span class="material-icons">chat</span>
+        <span class="text-xs"><%= course.comments.size %></span>
+      </div>
+    <% end %>
+  <% else %>
+    <%= link_to new_course_comment_path(course) do %>
+      <div class="flex items-end text-gray-400">
+        <span class="material-icons">chat</span>
+        <span class="text-xs"><%= course.comments.size %></span>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -11,18 +11,21 @@
         <h1 class="text-2xl"><%= @course.title %></h1>
         <p class="break-words"><%= @course.body %></p>
       </div>
-      <ul>
-        <div class="divider"></div>
 
-        <li class="flex items-start gap-1">
+      <div class="divider"></div>
+
+      <ul>
+        <li class="flex items-start gap-6">
           <%# Xシェア %>
           <%= link_to "https://twitter.com/intent/tweet?url=#{CGI.escape(course_url(@course))}&hashtags=お散歩マップ,散歩", target: "_blank", title: "Xでシェア" do %>
-            <div class="btn btn-xs btn-circle mr-4">
+            <div class="btn btn-xs btn-circle">
               <%= image_tag "x_twitter_mark.svg", class: "h-4" %>
             </div>
           <% end %>
           <%# いいねボタン %>
           <%= render "courses/like_button", course: @course %>
+          <%# コメント投稿用リンク %>
+          <%= render "courses/comment_button", course: @course %>
         </li>
 
         <div class="divider"></div>
@@ -55,8 +58,6 @@
       </div>
     </div>
   </div>
-
-  <div class="divider"></div>
 
   <%# マップ %>
   <div class="grid grid-cols-1">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -59,26 +59,23 @@
     </div>
   </div>
 
-  <%# マップ %>
-  <div class="grid grid-cols-1">
-    <div class="h-[70vh]">
-      <div id="show-map" class="w-full h-full"></div>
+  <%# タブ領域 %>
+  <div class="tabs tabs-lift tabs-bordered">
+    <input type="radio" id="map-tab" name="course_tabs" class="tab px-8" aria-label="マップ" checked />
+    <%# マップ %>
+    <div class="tab-content rounded-box bg-gray-50 shadow-lg p-6">
+      <div class="h-[70vh]">
+        <div id="show-map" class="w-full h-full"></div>
+      </div>
     </div>
-  </div>
 
-  <div class="divider"></div>
-
-  <%# コメント %>
-  <div class="grid grid-cols-1">
-    <%= render "comments/form", comment: @comment, course: @course %>
-
-    <% if @course.comments.present? %>
-      <ul id="comments" class="bg-base-100 rounded-box shadow-lg p-4 my-4">
+    <input type="radio" id="comment-tab" name="course_tabs" class="tab px-8" aria-label="コメント <%= @course.comments.size %>件" />
+    <%# コメント %>
+    <div class="tab-content rounded-box bg-gray-50 shadow-lg p-6">
+      <ul id="comments">
         <%= render @comments %>
       </ul>
-    <% else %>
-      <p class="text-sm my-4">コメントはまだありません</p>
-    <% end %>
+    </div>
   </div>
 </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,5 +42,8 @@
         <%= render 'shared/footer' %>
       </div>
     </div>
+
+    <%# コメント機能のturbo framesのターゲット %>
+    <%= turbo_frame_tag "modal" %>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     resources :likes, only: %i[create destroy], shallow: true
 
     # コメント機能
-    resources :comments, only: %i[create destroy], shallow: true
+    resources :comments, only: %i[new create destroy], shallow: true
   end
 
   # プライバシーポリシー


### PR DESCRIPTION
## 概要
コメント投稿用のフォームをモーダルで表示できるように変更しました

## 内容
### モーダル
コメント投稿用ボタンをクリックしたとき、turbo framesおよびstimulusを用いてモーダルを表示
- `application.html.erb`にturbo framesの領域を定義
- コメント投稿フォーム (`/comments/new.html.erb`) をdaisyUIのmodalコンポーネントを用いて作成 (このとき必要なルーティングおよびアクションも定義)
- コメント投稿ボタンをクリックしたとき、上記フォームが表示されるように`turbo-frame`属性を追加

### Stimulus (モーダルの開閉)
- stimulus用のコントローラを作成
``` bash
rails g stimulus modal
```
- モーダル部分にdata属性を追加
- 上記コントローラが接続 (コメント投稿フォームが表示) されたとき、モーダルを開くメソッドを定義
- コメント作成時、またはバツボタンが押されたとき、モーダルを閉じるメソッドをそれぞれ定義

### コメント作成および削除時の変更点
- turbo streamsを用いてコメント数が更新されるように変更
- コース詳細画面のタブが切り替わるように変更

Closes #239 