### PR TITLE
[Feature]プロフィール機能のためのカラムをusersテーブルに追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :liked_courses, through: :likes, source: :course
   has_many :comments, dependent: :destroy
+  has_one_attached :avatar
 
   # バリデーション
   validates :name, presence: true, length: { maximum: 20 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,9 @@ class User < ApplicationRecord
   # バリデーション
   validates :name, presence: true, length: { maximum: 20 }
   validates :uid, uniqueness: { scope: :provider }
-
+  validates :avatar, attachment: { purge: true, content_type: %r{\Aimage/(jpg|png|jpeg)\Z}, maximum: 5_242_880 }
+  validates :profile, length: { maximum: 1_000 }
+  
   # ユーザー自身のオブジェクトか確認するメソッド
   def own?(object)
     id == object&.user_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,7 +34,7 @@ class User < ApplicationRecord
   validates :uid, uniqueness: { scope: :provider }
   validates :avatar, attachment: { purge: true, content_type: %r{\Aimage/(jpg|png|jpeg)\Z}, maximum: 5_242_880 }
   validates :profile, length: { maximum: 1_000 }
-  
+
   # ユーザー自身のオブジェクトか確認するメソッド
   def own?(object)
     id == object&.user_id

--- a/app/validators/attachment_validator.rb
+++ b/app/validators/attachment_validator.rb
@@ -12,6 +12,8 @@ class AttachmentValidator < ActiveModel::EachValidator
           has_error = true unless validate_content_type(record, attribute, file)
           break
         end
+      else
+        has_error = true unless validate_content_type(record, attribute, value)
       end
     end
 
@@ -21,6 +23,8 @@ class AttachmentValidator < ActiveModel::EachValidator
           has_error = true unless validate_maximum(record, attribute, file)
           break
         end
+      else
+        has_error = true unless validate_maximum(record, attribute, value)
       end
     end
 

--- a/db/migrate/20250616014929_add_avatar_and_profile_to_users.rb
+++ b/db/migrate/20250616014929_add_avatar_and_profile_to_users.rb
@@ -1,0 +1,6 @@
+class AddAvatarAndProfileToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :avatar, :string
+    add_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_06_07_005151) do
+ActiveRecord::Schema[7.0].define(version: 2025_06_16_014929) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
@@ -50,7 +50,6 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_07_005151) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["course_id"], name: "index_comments_on_course_id"
-    t.index ["user_id", "course_id"], name: "index_comments_on_user_id_and_course_id", unique: true
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
@@ -100,6 +99,8 @@ ActiveRecord::Schema[7.0].define(version: 2025_06_07_005151) do
     t.datetime "updated_at", null: false
     t.string "provider"
     t.string "uid"
+    t.string "avatar"
+    t.text "profile"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 概要
usersテーブルにプロフィール機能実装のためのカラムを追加しました

## 内容
### カラム
以下のコマンドでマイグレーションをファイルを生成し、userモデルに適用
``` bash
rails g migration add_avatar_and_profile_to_users avatar:string profile:text
```
- avatar:string (アバター画像)
- profile:text (自己紹介)

### バリデーション
カスタムバリデータ (app/validators/attachment_validator.rb) を編集
- avatar：ファイル形式がjpg, png, jpegのいずれか、サイズが5 MB以下
- profile：1000文字以下

### 関連付け
- usersテーブルのレコードに一つのファイルを添付できるようにActive Storageの関連付けを定義

## 確認
db/schema.rbにカラムが追加されていることを確認しました

Closes #156 